### PR TITLE
Adding cli support to template project

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -70,8 +70,7 @@ def subprocess_in_dir(command, dirpath=None):
     if dirpath is None:
         dirpath = os.getcwd()
 
-    with in_dir(dirpath):
-        return subprocess.check_call(shlex.split(command))
+    subprocess.check_call(shlex.split(command), cwd=dirpath)
 
 
 def load_cookiecutter_json():

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = {{ cookiecutter.project_slug }}
+name = {{ cookiecutter.project_slug.replace('_', '-') }}
 url = {{ cookiecutter.project_source_url }}
 project_urls =
     Documentation = {{ cookiecutter.project_doc_url }}
@@ -32,4 +32,4 @@ where = src
 
 [options.entry_points]
 console_scripts =
-    {{ cookiecutter.project_slug | replace('-', '_') }} = {{ cookiecutter.project_slug | replace('-', '_') }}.cli:main
+    {{ cookiecutter.project_slug.replace('_', '-') }} = {{ cookiecutter.project_slug }}.cli:main

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli/__init__.py
@@ -1,0 +1,53 @@
+"""
+This module bonds the entry points (console scripts) to the argument parser
+interface. By doing so, console scripts can either be bonded to:
+    1. Raw python functions
+    2. Different argument parsing solutions
+
+New interfaces can be added by creating a submodule to this package and
+exposing a "cli" function in that module. See the scenario examples below to
+understand how to add the newly created interface to console scripts.
+
+This module dynamically loads the submodules and exposes as its own attributes
+the cli function of the submodules as the name of the submodule.
+For example in the submodule "main.py" the "cli" function will be an attribute
+of this module available for use/calling as "cli.main".
+
+The following two scenarios are equivalent due to the dynamic sub module import
+and attribute allocation.
+
+Scenario 1:
+  In Python modules/executables:
+    from .cli import main
+    main.cli()
+  In setup.py or setup.cfg (recomended):
+    console_scripts =
+      my_script = {{ cookiecutter.project_slug }}.cli.main:cli
+
+Scenario 2 (recomended):
+  In Python modules/executables:
+    from . import cli
+    cli.main()
+  In setup.py or setup.cfg (recomended):
+    console_scripts =
+      my_script = {{ cookiecutter.project_slug }}.cli:main
+
+"""
+import pkgutil
+import importlib
+import pathlib
+import sys
+
+for module in pkgutil.iter_modules(
+        path=[pathlib.Path(__file__).parent.absolute()]):
+
+    _cli = importlib.import_module(f".{module.name}", package=__name__)
+
+    if hasattr(_cli, "cli"):
+        setattr(sys.modules[__name__], module.name, _cli.cli)
+    else:
+        raise AttributeError(f'"{module.name}" module in cli does not have an'
+                             ' cli attribute, required to interface with'
+                             ' console scripts')
+
+    del _cli

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli/main.py
@@ -1,0 +1,38 @@
+"""
+This module holds the console script argument schema for the main script of
+{{ cookiecutter.project_slug }} which can be invoked by {{ cookiecutter.project_slug.replace('_', '-') }}
+"""
+import platform
+import sys
+import click
+
+from .. import __version__
+
+
+def cli():
+    """
+    Main CLI interface exposed to the cli module and exposed to the console
+    script.
+    """
+    click.echo(f"Calling {sys.argv[0]}")
+
+
+@click.command()
+def run():
+    """
+    The function that gets invoked by the subcommand "run"
+    """
+    click.echo('Running the script')
+
+
+@click.command()
+def version():
+    """
+    The function that gets invoked by the subcommand "version"
+    """
+    click.echo(f"Python {platform.python_version()}\n"
+               f"{{ cookiecutter.project_slug }} {__version__}")
+
+
+cli.add_command(run)  # pylint: disable=no-member
+cli.add_command(version)  # pylint: disable=no-member


### PR DESCRIPTION
* Added click based argument parser to template project
* updated setup.cfg to include a console script by default based on project_slug
* Using cwd parameter in subprocess.check_call instead of yielding the dir